### PR TITLE
Add CLP and masterKey config options and auditing of _User, _Role, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,16 @@ The third argument to `parse-auditor` is a config object. The structure of this 
     fieldPrefix: 'meta_',
     fieldPostfix: '',
     parseSDK: Parse,
+    useMasterKey: false,
+    clp: {}
 }
 ```
 
 For example:
 ```javascript
 const ParseAuditor = require('parse-auditor');
-ParseAuditor(['Patient', 'Clinic'], ['Patient'], { classPostfix: '_HISTORY' })
+const customConfig = { classPostfix: '_HISTORY', useMasterKey: true, clp: {create: { '*': true }, addField: { '*': true } } };
+ParseAuditor(['Patient', 'Clinic'], ['Patient'], customConfig);
 ```
 
 This will track all edits to these classes (creates, updates, deletes) as well as any views to a `Patient`. This will

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Let say you have a healthcare app that needs HIPAA logging around its Patient an
 your app's cloud code (i.e. `cloud/main.js`):
 
 ```javascript
-const ParseAuditor = require('./parse-auditor.js');
+const ParseAuditor = require('parse-auditor');
 ParseAuditor(['Patient', 'Clinic'])
 ```
 
@@ -34,7 +34,7 @@ respectively.
 
 You can also tell `parse-auditor` which classes to track reads on:
 ```javascript
-const ParseAuditor = require('./parse-auditor.js');
+const ParseAuditor = require('parse-auditor');
 ParseAuditor(['Patient', 'Clinic'], ['Patient'])
 ```
 
@@ -85,7 +85,7 @@ The third argument to `parse-auditor` is a config object. The structure of this 
 
 For example:
 ```javascript
-const ParseAuditor = require('./parse-auditor.js');
+const ParseAuditor = require('parse-auditor');
 ParseAuditor(['Patient', 'Clinic'], ['Patient'], { classPostfix: '_HISTORY' })
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,19 +20,12 @@ const setCLP = async (subjectClass, config = CONFIG_DEFAULTS) => {
     const a = new Parse.Schema(fixedClassName);
 
     await a.get()
-    .catch(error => {
-        a.setCLP(config.clp);
-        if (!config.useMasterKey){
-            a.save()
-            .then(() => {
-                console.log(`parse-auditor successfully created class '${fixedClassName}'. Ignore any previous errors about this class`);
-            });
-        }else{
-            a.save({useMasterKey: true})
-            .then(() => {
-                console.log(`parse-auditor successfully created class '${fixedClassName}'. Ignore any previous errors about this class`);
-            });
-        }
+    .catch(() => {
+        a.setCLP(config.clp)
+        .save({useMasterKey: config.useMasterKey})
+        .then(() => {
+            console.log(`parse-auditor successfully created class '${fixedClassName}'. Ignore any previous errors about this class`);
+        });
     })
 };
 
@@ -50,12 +43,7 @@ const audit = async (user, action, subjectClass, subject, config = CONFIG_DEFAUL
     a.set(`${config.fieldPrefix}action${config.fieldPostfix}`, action);
     a.set(`${config.fieldPrefix}class${config.fieldPostfix}`, subjectClass);
     a.set(`${config.fieldPrefix}subject${config.fieldPostfix}`, subject);
-    
-    if (!config.useMasterKey){
-        a.save({useMasterKey: true});
-    }else{
-        a.save({useMasterKey: true});
-    }
+    a.save({useMasterKey: config.useMasterKey});
 };
 
 const init = (auditModifiedClasses, auditAccessClasses = [], options = {}) => {

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ const init = (auditModifiedClasses, auditAccessClasses = [], options = {}) => {
     const config = {
         classPrefix, classPostfix, fieldPrefix, fieldPostfix, parseSDK, useMasterKey, clp
     };
-    
+
     auditModifiedClasses.forEach((c) => {
         if (Object.keys(config.clp).length !== 0){
             parseSDK.Cloud.define(`audit${config.classPrefix}${c}${config.classPostfix}SetCLP`, async req =>  setCLP(c, config));

--- a/src/index.js
+++ b/src/index.js
@@ -41,8 +41,10 @@ const audit = async (user, action, subjectClass, subject, config = CONFIG_DEFAUL
     a.set(`${config.fieldPrefix}subject${config.fieldPostfix}`, subject);
     
     if (!config.useMasterKey){
+        console.log('****');
         a.save();
     }else{
+        console.log('111111');
         a.save({useMasterKey: true});
     }
 };
@@ -60,8 +62,8 @@ const init = (auditModifiedClasses, auditAccessClasses = [], options = {}) => {
     };
 
     auditModifiedClasses.forEach((c) => {
-        parseSDK.Cloud.define(`audit${config.classPrefix}${subjectClass}${config.classPostfix}SetCLP`, async req =>  setCLP(c, config));
-        parseSDK.Cloud.run(`audit${config.classPrefix}${subjectClass}${config.classPostfix}SetCLP`);
+        //parseSDK.Cloud.define(`audit${config.classPrefix}${subjectClass}${config.classPostfix}SetCLP`, async req =>  setCLP(c, config));
+        //parseSDK.Cloud.run(`audit${config.classPrefix}${subjectClass}${config.classPostfix}SetCLP`);
         parseSDK.Cloud.afterSave(c, async req => audit(req.user, 'SAVE', c, req.object, config));
         parseSDK.Cloud.afterDelete(c, async req => audit(req.user, 'DELETE', c, req.object, config));
     });

--- a/src/index.js
+++ b/src/index.js
@@ -15,10 +15,12 @@ const setCLP = async (subjectClass, config = CONFIG_DEFAULTS) => {
     if (Object.keys(config.clp).length !== 0){
         a.setCLP(config.clp);
     }
-    
+
     if (!config.useMasterKey){
+        console.log('****');
         a.save();
     }else{
+        console.log('111111');
         a.save({useMasterKey: true});
     }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ const setCLP = async (subjectClass, config = CONFIG_DEFAULTS) => {
 
     if (config.useMasterKey === false){
         console.log('****');
-        a.save();
+        a.save({useMasterKey: true});
     }else{
         console.log('111111');
         a.save({useMasterKey: true});
@@ -41,10 +41,8 @@ const audit = async (user, action, subjectClass, subject, config = CONFIG_DEFAUL
     a.set(`${config.fieldPrefix}subject${config.fieldPostfix}`, subject);
     
     if (config.useMasterKey === false){
-        console.log('****');
-        a.save();
+        a.save({useMasterKey: true});
     }else{
-        console.log('111111');
         a.save({useMasterKey: true});
     }
 };
@@ -62,8 +60,8 @@ const init = (auditModifiedClasses, auditAccessClasses = [], options = {}) => {
     };
 
     auditModifiedClasses.forEach((c) => {
-        //parseSDK.Cloud.define(`audit${config.classPrefix}${subjectClass}${config.classPostfix}SetCLP`, async req =>  setCLP(c, config));
-        //parseSDK.Cloud.run(`audit${config.classPrefix}${subjectClass}${config.classPostfix}SetCLP`);
+        parseSDK.Cloud.define(`audit${config.classPrefix}${subjectClass}${config.classPostfix}SetCLP`, async req =>  setCLP(c, config));
+        parseSDK.Cloud.run(`audit${config.classPrefix}${subjectClass}${config.classPostfix}SetCLP`);
         parseSDK.Cloud.afterSave(c, async req => audit(req.user, 'SAVE', c, req.object, config));
         parseSDK.Cloud.afterDelete(c, async req => audit(req.user, 'DELETE', c, req.object, config));
     });

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ const audit = async (user, action, subjectClass, subject, config = CONFIG_DEFAUL
     a.set(`${config.fieldPrefix}action${config.fieldPostfix}`, action);
     a.set(`${config.fieldPrefix}class${config.fieldPostfix}`, subjectClass);
     a.set(`${config.fieldPrefix}subject${config.fieldPostfix}`, subject);
-    a.save({useMasterKey: config.useMasterKey});
+    a.save(null,{useMasterKey: config.useMasterKey});
 };
 
 const init = (auditModifiedClasses, auditAccessClasses = [], options = {}) => {
@@ -60,8 +60,9 @@ const init = (auditModifiedClasses, auditAccessClasses = [], options = {}) => {
 
     auditModifiedClasses.forEach((c) => {
         if (Object.keys(config.clp).length !== 0){
-            parseSDK.Cloud.define(`audit${config.classPrefix}${c}${config.classPostfix}SetCLP`, async req =>  setCLP(c, config));
-            parseSDK.Cloud.run(`audit${config.classPrefix}${c}${config.classPostfix}SetCLP`);
+            const fixedClassName = fixClassNameIfNeeded(c,config);
+            parseSDK.Cloud.define(`audit${fixedClassName}SetCLP`, async req =>  setCLP(c, config));
+            parseSDK.Cloud.run(`audit${fixedClassName}SetCLP`);
         }
         parseSDK.Cloud.afterSave(c, async req => audit(req.user, 'SAVE', c, req.object, config));
         parseSDK.Cloud.afterDelete(c, async req => audit(req.user, 'DELETE', c, req.object, config));

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,8 @@ const init = (auditModifiedClasses, auditAccessClasses = [], options = {}) => {
     };
 
     auditModifiedClasses.forEach((c) => {
-        setCLP(c, config);
+        parseSDK.Cloud.define(`audit${config.classPrefix}${subjectClass}${config.classPostfix}SetCLP`, async req =>  setCLP(c, config));
+        parseSDK.Cloud.run(`audit${config.classPrefix}${subjectClass}${config.classPostfix}SetCLP`);
         parseSDK.Cloud.afterSave(c, async req => audit(req.user, 'SAVE', c, req.object, config));
         parseSDK.Cloud.afterDelete(c, async req => audit(req.user, 'DELETE', c, req.object, config));
     });

--- a/src/index.js
+++ b/src/index.js
@@ -60,9 +60,7 @@ const init = (auditModifiedClasses, auditAccessClasses = [], options = {}) => {
 
     auditModifiedClasses.forEach((c) => {
         if (Object.keys(config.clp).length !== 0){
-            const fixedClassName = fixClassNameIfNeeded(c,config);
-            parseSDK.Cloud.define(`audit${fixedClassName}SetCLP`, async req =>  setCLP(c, config));
-            parseSDK.Cloud.run(`audit${fixedClassName}SetCLP`);
+            setCLP(c, config);
         }
         parseSDK.Cloud.afterSave(c, async req => audit(req.user, 'SAVE', c, req.object, config));
         parseSDK.Cloud.afterDelete(c, async req => audit(req.user, 'DELETE', c, req.object, config));

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const setCLP = async (subjectClass, config = CONFIG_DEFAULTS) => {
         a.setCLP(config.clp);
     }
 
-    if (!config.useMasterKey){
+    if (config.useMasterKey === false){
         console.log('****');
         a.save();
     }else{
@@ -40,7 +40,7 @@ const audit = async (user, action, subjectClass, subject, config = CONFIG_DEFAUL
     a.set(`${config.fieldPrefix}class${config.fieldPostfix}`, subjectClass);
     a.set(`${config.fieldPrefix}subject${config.fieldPostfix}`, subject);
     
-    if (!config.useMasterKey){
+    if (config.useMasterKey === false){
         console.log('****');
         a.save();
     }else{

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const setCLP = async (subjectClass, config = CONFIG_DEFAULTS) => {
     await a.get()
     .catch(() => {
         a.setCLP(config.clp)
-        .save({useMasterKey: config.useMasterKey})
+        .save()
         .then(() => {
             console.log(`parse-auditor successfully created class '${fixedClassName}'. Ignore any previous errors about this class`);
         });


### PR DESCRIPTION
Awesome package! I was testing and added some more capabilities.

One thing I noticed is that parse-server will only let node modules change class level permissions (CLPs) if the CLPs are already public (which they are by default). It looks like parse-server ignores operations otherwise which I guess is a good thing as pre-installed modules should only be able to use the masterKey and modify CLPs if you want it to.

To circumvent this, you have to point to the index file of parse-audit directly in main.js of your CloudCode. So it looked like the following:

```const ParseAuditor = require('../node_modules/parse-auditor/src/index.js');```

If not changing CLPs or if you don't need the masterKey, using below works:

```const ParseAuditor = require('parse-auditor');```

Note that since this is an auditing package, parse-server admins probably shouldn't use the default CLP's in parse-server as they are public read/write/add fields, etc. and gives all of this access to the auditing classes. So they should set them accordingly and can do so through the config options or Parse Dashboard.

I also fixed a small bug when attempting to audit classes like `_User` and `_Role` when using the default config. The bug occurs because no prefix is set and Parse only lets its own classes begin with `_`